### PR TITLE
Change OIO prefix to oboInOwl

### DIFF
--- a/registry/monarch_context.jsonld
+++ b/registry/monarch_context.jsonld
@@ -103,7 +103,7 @@
         "OBAN": "http://purl.org/oban/",
         "OBI": "http://purl.obolibrary.org/obo/OBI_",
         "OBO": "http://purl.obolibrary.org/obo/",
-        "OIO": "http://www.geneontology.org/formats/oboInOwl#",
+        "oboInOwl": "http://www.geneontology.org/formats/oboInOwl#",
         "OMIA": "http://purl.obolibrary.org/obo/OMIA_",
         "OMIA-breed": "https://monarchinitiative.org/model/OMIA-breed:",
         "OMIM": "http://purl.obolibrary.org/obo/OMIM_",


### PR DESCRIPTION
It seems that the prefix for the same URI `http://www.geneontology.org/formats/oboInOwl#` is different between monarch_context.jsonld and go_obo_context.jsonld.

@cmungall 