### PR TITLE
Changed SKOS URI to match SKOS specification

### DIFF
--- a/registry/commons_context.jsonld
+++ b/registry/commons_context.jsonld
@@ -796,7 +796,7 @@
         "pigQTL": "https://www.animalgenome.org/cgi-bin/QTLdb/SS/qdetails?QTL_ID=",
         "rainbow_troutQTL": "https://www.animalgenome.org/cgi-bin/QTLdb/OM/qdetails?QTL_ID=",
         "sheepQTL": "https://www.animalgenome.org/cgi-bin/QTLdb/OA/qdetails?QTL_ID=",
-        "skos": "https://www.w3.org/TR/skos-reference/#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
         "xml": "http://www.w3.org/XML/1998/namespace",
         "AAO": "http://purl.obolibrary.org/obo/AAO_",
         "ADW": "http://purl.obolibrary.org/obo/ADW_",

--- a/registry/monarch_context.jsonld
+++ b/registry/monarch_context.jsonld
@@ -178,7 +178,7 @@
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "sheepQTL": "https://www.animalgenome.org/cgi-bin/QTLdb/OA/qdetails?QTL_ID=",
-        "skos": "https://www.w3.org/TR/skos-reference/#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
         "xml": "http://www.w3.org/XML/1998/namespace",
         "xsd": "http://www.w3.org/2001/XMLSchema#"
     }


### PR DESCRIPTION
See https://www.w3.org/TR/2009/REC-skos-reference-20090818/#vocab for reason for this request.

I tried running `make` to update the other files but encountered a number of errors.