### PR TITLE
fix(monarch): corrected iri for efo curie

### DIFF
--- a/registry/monarch_context.jsonld
+++ b/registry/monarch_context.jsonld
@@ -34,7 +34,7 @@
         "DrugBank": "http://www.drugbank.ca/drugs/",
         "EC": "http://www.enzyme-database.org/query.php?ec=",
         "ECO": "http://purl.obolibrary.org/obo/ECO_",
-        "EFO": "http://purl.obolibrary.org/obo/EFO_",
+        "EFO": "http://www.ebi.ac.uk/efo/EFO_",
         "EMAPA": "http://purl.obolibrary.org/obo/EMAPA_",
         "EMMA": "https://www.infrafrontier.eu/search?keyword=EM:",
         "ENSEMBL": "http://ensembl.org/id/",


### PR DESCRIPTION
This PR corrects the IRI for  `EFO` in the  **monarch_context**  because `EFO:0001461`  does not resolve into functional link.

Compare http://www.ebi.ac.uk/efo/EFO_0001461 and http://purl.obolibrary.org/efo/EFO_0001461

