### PR TITLE
chore(license): add apache2 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+   Copyright (c) 2021 PrefixCommons contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
This PR adds a Apache 2.0 license to ensure software is safe to use.  

No license implies either:
1. Nobody can use this software
2. Or perhaps it can be argued that CC0 was  intended which risks ligation from patent trolls (http://lists.opensource.org/pipermail/license-review_lists.opensource.org/2012-February/001565.html)

Resolves #15 